### PR TITLE
Fix build break

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ PARSER_HEADERS 	:= $(PARSER_DIR)/src
 
 HIDE     := @
 CC       := gcc
-CFLAGS   := -g -Wall
+CFLAGS   := -g -Wall -std=gnu99
 INCLUDES := -I $(PARSER_HEADERS)
 LDFLAGS	 := -L $(PARSER_DIR) -liniparser -lz
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It follows the [IPMI Management FRU Information Storage Definition Specification
 ## Usage:
 Generating a FRU data file:
 ```
-$ ipmi-fru-it -w -s 2048 -c fru.conf -o FRU.bin
+$ ipmi-fru-it -s 256 -c fru.conf -o FRU.bin
 ```
 Reading a FRU data file:
 ```

--- a/ipmi-fru-it.c
+++ b/ipmi-fru-it.c
@@ -47,12 +47,12 @@ const char* FRU_FILE_ID     = "fru_file_id";
 
 int (*packer)(const char *, char **);
 
-inline uint8_t get_6bit_ascii(char c)
+static inline uint8_t get_6bit_ascii(char c)
 {
     return (c - 0x20) & 0x3f;
 }
 
-inline uint8_t get_aligned_size(uint8_t size, uint8_t align)
+static inline uint8_t get_aligned_size(uint8_t size, uint8_t align)
 {
     return (size + align - 1) & ~(align - 1);
 }


### PR DESCRIPTION
Using Ubuntu 18 default gcc cannot make with error:
undefined reference to `get_6bit_ascii' and `get_aligned_size'
Add static symbol to avoid the build error.

And remove -w parameter in README, it cause generate FRU fail.

Signed-off-by: Brian Ma <chma0@nuvoton.com>